### PR TITLE
Fixed overflow when width of buffer exceeds screen width | This doesn…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # uilive [![GoDoc](https://godoc.org/github.com/gosuri/uilive?status.svg)](https://godoc.org/github.com/gosuri/uilive)
 
 uilive is a go library for updating terminal output in realtime. It provides a buffered [io.Writer](https://golang.org/pkg/io/#Writer) that is flushed at a timed interval. uilive powers [uiprogress](https://github.com/gosuri/uiprogress).
+It works for posix and Windows too!
 
 ## Usage Example
 

--- a/writer.go
+++ b/writer.go
@@ -48,7 +48,7 @@ type Writer struct {
 	lineCount int
 }
 
-func InitializeTerminalWidth() {
+func initTermWidth() {
 	err := termbox.Init()
 	termWidth, _ = termbox.Size()
 	if err == nil {
@@ -59,6 +59,7 @@ func InitializeTerminalWidth() {
 
 // New returns a new writer with defaults
 func New() *Writer {
+	initTermWidth()
 	return &Writer{
 		Out:             Out,
 		RefreshInterval: RefreshInterval,

--- a/writer.go
+++ b/writer.go
@@ -1,3 +1,4 @@
+// Package uilive provides a writer that updates the UI
 package uilive
 
 import (
@@ -5,6 +6,9 @@ import (
 	"errors"
 	"io"
 	"os"
+	"os/exec"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -15,13 +19,19 @@ const ESC = 27
 // RefreshInterval is the default refresh interval to update the ui
 var RefreshInterval = time.Millisecond
 
-// Out is the default output writer for the Writer
+// overflow is handled if width of buffer exceeds screen width
+var overflowHandled = false
+
+// Width of terminal
+var termWidth int
+
+// Out is the default out for the writer
 var Out = os.Stdout
 
 // ErrClosedPipe is the error returned when trying to writer is not listening
 var ErrClosedPipe = errors.New("uilive: read/write on closed pipe")
 
-// Writer is a buffered the writer that updates the terminal. The contents of writer will be flushed on a timed interval or when Flush is called.
+// Writer represent the writer that updates the UI
 type Writer struct {
 	// Out is the writer to write to
 	Out io.Writer
@@ -31,7 +41,6 @@ type Writer struct {
 
 	// stopChan is buffered channel for stopping the listener
 	stopChan chan struct{}
-
 	// running is flag for determining if the listerner is running
 	running bool
 
@@ -40,8 +49,12 @@ type Writer struct {
 	lineCount int
 }
 
-// New returns a new Writer with defaults
+// New returns a new writer with defaults
 func New() *Writer {
+	if termWidth = getTtyLength(); termWidth != 0 {
+		overflowHandled = true
+	}
+
 	return &Writer{
 		Out:             Out,
 		RefreshInterval: RefreshInterval,
@@ -52,7 +65,6 @@ func New() *Writer {
 
 // Flush writes to the out and resets the buffer. It should be called after the last call to Write to ensure that any data buffered in the Writer is written to output.
 // Any incomplete escape sequence at the end is considered complete for formatting purposes.
-// An error is returned if the contents of the buffer cannot be written to the underlying output stream
 func (w *Writer) Flush() error {
 	w.mtx.Lock()
 	defer w.mtx.Unlock()
@@ -64,9 +76,19 @@ func (w *Writer) Flush() error {
 	w.clearLines()
 
 	lines := 0
+	var currentLine bytes.Buffer
 	for _, b := range w.buf.Bytes() {
 		if b == '\n' {
 			lines++
+			currentLine.Reset()
+		} else {
+			currentLine.Write([]byte{b})
+
+			// if len of currentLine is > terminal len, add `1` to `lines`
+			if overflowHandled && currentLine.Len() > termWidth {
+				lines++
+				currentLine.Reset()
+			}
 		}
 	}
 	w.lineCount = lines
@@ -75,18 +97,33 @@ func (w *Writer) Flush() error {
 	return err
 }
 
-// Start starts the listener in a non-blocking manner
+// Start starts the listener in a non blocking manner
 func (w *Writer) Start() {
 	go w.Listen()
 }
 
-// Stop stops the listener that updates the terminal
+func getTtyLength() int {
+	cmd := exec.Command("stty", "size")
+	cmd.Stdin = os.Stdin
+	out, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+	splits := strings.Split(strings.Trim(string(out), "\n"), " ")
+	length, err := strconv.ParseInt(splits[1], 0, 0)
+	if err != nil {
+		return 0
+	}
+	return int(length)
+}
+
+// Stop stops the listener that updates the UI
 func (w *Writer) Stop() {
 	w.Flush()
 	w.stopChan <- struct{}{}
 }
 
-// Listen listens for updates to the writer's buffer and flushes to the out provided. It blocks the runtime.
+// Listen listens for updates to the writers buffer and flushes to the out. It blocks the runtime.
 func (w *Writer) Listen() {
 	if w.running {
 		return
@@ -107,9 +144,9 @@ func (w *Writer) Wait() {
 	w.Flush()
 }
 
-// Write save the contents of b to its buffers. The only errors returned are ones encountered while writing to the underlying buffer.
-func (w *Writer) Write(b []byte) (n int, err error) {
+// Write writes buf to the writer b. The only errors returned are ones encountered while writing to the underlying output stream.
+func (w *Writer) Write(buf []byte) (n int, err error) {
 	w.mtx.Lock()
 	defer w.mtx.Unlock()
-	return w.buf.Write(b)
+	return w.buf.Write(buf)
 }


### PR DESCRIPTION
Fixed overflow when width of buffer exceeds screen width. This doesnt work for windows.
This gets the terminal size and validates if buffer width exceeds screen width.
