### PR TITLE
Support for intermediate writers.

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -21,6 +21,12 @@ var Out = os.Stdout
 // ErrClosedPipe is the error returned when trying to writer is not listening
 var ErrClosedPipe = errors.New("uilive: read/write on closed pipe")
 
+// FdWriter is a writer with a file descriptor.
+type FdWriter interface {
+	io.Writer
+	Fd() uintptr
+}
+
 // Writer is a buffered the writer that updates the terminal. The contents of writer will be flushed on a timed interval or when Flush is called.
 type Writer struct {
 	// Out is the writer to write to

--- a/writer_windows.go
+++ b/writer_windows.go
@@ -5,7 +5,6 @@ package uilive
 import (
 	"fmt"
 	"github.com/mattn/go-isatty"
-	"os"
 	"syscall"
 	"unsafe"
 )
@@ -44,7 +43,7 @@ type consoleScreenBufferInfo struct {
 }
 
 func (w *Writer) clearLines() {
-	f, ok := w.Out.(*os.File)
+	f, ok := w.Out.(FdWriter)
 	if ok && !isatty.IsTerminal(f.Fd()) {
 		ok = false
 	}


### PR DESCRIPTION
On Windows it's impossible right now to output to colorized writers, such as [mattn/go-colorable](https://github.com/mattn/go-colorable), since they need to wrap the `*os.File` in their own implementation of `io.Writer`, thus losing access to the terminal's file descriptor.

The code now checks for `FdWriter`, an interface type that `*os.File` implements out of the box. This way one can forward the terminal's file descriptor to uilive while using an intermediate writer.

`FdWriter` didn't really _need_ to be exported but I don't like the idea of some types having different behaviour based on an undocumented API.
