### PR TITLE
Added bypass writer which allows data to be written to the underlying output

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -13,9 +13,12 @@ func main() {
 	// start listening for updates and render
 	writer.Start()
 
-	for i := 0; i <= 100; i++ {
-		fmt.Fprintf(writer, "Downloading.. (%d/%d) GB\n", i, 100)
-		time.Sleep(time.Millisecond * 5)
+	for _, f := range []string{"Foo.zip", "Bar.iso"} {
+		for i := 0; i <= 50; i++ {
+			fmt.Fprintf(writer, "Downloading %s.. (%d/%d) GB\n", f, i, 50)
+			time.Sleep(time.Millisecond * 25)
+		}
+		fmt.Fprintf(writer.Bypass(), "Downloaded %s\n", f)
 	}
 
 	fmt.Fprintln(writer, "Finished: Downloaded 100GB")


### PR DESCRIPTION
I'm not sure if this is something you actually want, but I've found it convenient to still be able to output log messages while the uiprogress output is running. At the moment, any 'normal' output gets overwritten by the next refresh of the uilive buffer, and you end up with lots of progress bars left behind due to the output getting out of sync.

By clearing the uilive.Writer lines and resetting the line count, log output (for example) can
be written to the underlying output without being overwritten by the next update from the
buffer.

I've also exposed a similar method on the uiprogress.Progress object, which I will create a PR for.
