### PR TITLE
Using time.Ticker for running stoppable listener. Fix edge case where…

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -103,10 +103,17 @@ func (w *Writer) Listen() {
 	for {
 		select {
 		case <-w.ticker.C:
-			w.Flush()
+			w.mtx.Lock()
+			if w.ticker != nil {
+				w.Flush()
+			}
+
+			w.mtx.Unlock()
 		case <-w.tdone:
+			w.mtx.Lock()
 			w.ticker.Stop()
 			w.ticker = nil
+			w.mtx.Unlock()
 			return
 		}
 	}

--- a/writer.go
+++ b/writer.go
@@ -103,12 +103,9 @@ func (w *Writer) Listen() {
 	for {
 		select {
 		case <-w.ticker.C:
-			w.mtx.Lock()
 			if w.ticker != nil {
 				w.Flush()
 			}
-
-			w.mtx.Unlock()
 		case <-w.tdone:
 			w.mtx.Lock()
 			w.ticker.Stop()

--- a/writer_test.go
+++ b/writer_test.go
@@ -15,7 +15,9 @@ func TestWriter(t *testing.T) {
 		fmt.Fprintln(w, "foo")
 	}
 	w.Stop()
-	want := "foo\nfoo\n"
+	fmt.Fprintln(b, "bar")
+
+	want := "foo\nfoo\nbar\n"
 	if b.String() != want {
 		t.Fatalf("want %q, got %q", want, b.String())
 	}


### PR DESCRIPTION
… flush happens after the listener is stopped.

This is part of the fix to https://github.com/gosuri/uiprogress/issues/20
