### PR TITLE
Move the cursor up one line

### DIFF
--- a/writer_posix.go
+++ b/writer_posix.go
@@ -8,7 +8,7 @@ import (
 
 func (w *Writer) clearLines() {
 	for i := 0; i < w.lineCount; i++ {
-		fmt.Fprintf(w.Out, "%c[%dA", ESC, 0) // move the cursor up
+		fmt.Fprintf(w.Out, "%c[%dA", ESC, 1) // move the cursor up
 		fmt.Fprintf(w.Out, "%c[2K\r", ESC)   // clear the line
 	}
 }

--- a/writer_windows.go
+++ b/writer_windows.go
@@ -49,7 +49,7 @@ func (w *Writer) clearLines() {
 	}
 	if !ok {
 		for i := 0; i < w.lineCount; i++ {
-			fmt.Fprintf(w.Out, "%c[%dA", ESC, 0) // move the cursor up
+			fmt.Fprintf(w.Out, "%c[%dA", ESC, 1) // move the cursor up
 			fmt.Fprintf(w.Out, "%c[2K\r", ESC)   // clear the line
 		}
 		return


### PR DESCRIPTION
XTerm interprets "cursor up N lines" as "cursor up 1 line" for all N <=
0. rxvt-unicode (and possibly others), however, treat "cursor up 0
lines" as moving 0 lines.

Fixes gosuri/uiprogress#16
