### PR TITLE
Change uilive.Out to type io.Writer

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -16,7 +16,7 @@ const ESC = 27
 var RefreshInterval = time.Millisecond
 
 // Out is the default output writer for the Writer
-var Out = os.Stdout
+var Out = io.Writer(os.Stdout)
 
 // ErrClosedPipe is the error returned when trying to writer is not listening
 var ErrClosedPipe = errors.New("uilive: read/write on closed pipe")


### PR DESCRIPTION
it's set to be os.Stdout by default, which is an *os.File, though it's
only used as an io.Writer.