### PR TITLE
Allow Start to be called immediately after Stop

### DIFF
--- a/writer_test.go
+++ b/writer_test.go
@@ -22,3 +22,14 @@ func TestWriter(t *testing.T) {
 		t.Fatalf("want %q, got %q", want, b.String())
 	}
 }
+
+func TestStartCalledTwice(t *testing.T) {
+	w := New()
+	b := &bytes.Buffer{}
+	w.Out = b
+
+	w.Start()
+	w.Stop()
+	w.Start()
+	w.Stop()
+}


### PR DESCRIPTION
- Prior to this change the library would panic if you called Start a
  second time immediately after calling Stop
- This change updates Stop to block until the background Listen method is
  finished

cc @ljfranklin