### PR TITLE
Bug Fixes + Features

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/asahasrabuddhe/uilive"
+	"github.com/gosuri/uilive"
 )
 
 func main() {

--- a/example/main.go
+++ b/example/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gosuri/uilive"
+	"github.com/asahasrabuddhe/uilive"
 )
 
 func main() {
@@ -13,14 +13,15 @@ func main() {
 	// start listening for updates and render
 	writer.Start()
 
-	for _, f := range []string{"Foo.zip", "Bar.iso"} {
+	for _, f := range [][]string{{"Foo.zip", "Bar.iso"}, {"Baz.tar.gz", "Qux.img"}} {
 		for i := 0; i <= 50; i++ {
-			fmt.Fprintf(writer, "Downloading %s.. (%d/%d) GB\n", f, i, 50)
+			_, _ = fmt.Fprintf(writer, "Downloading %s.. (%d/%d) GB\n", f[0], i, 50)
+			_, _ = fmt.Fprintf(writer.Newline(), "Downloading %s.. (%d/%d) GB\n", f[1], i, 50)
 			time.Sleep(time.Millisecond * 25)
 		}
-		fmt.Fprintf(writer.Bypass(), "Downloaded %s\n", f)
+		_, _ = fmt.Fprintf(writer.Bypass(), "Downloaded %s\n", f[0])
+		_, _ = fmt.Fprintf(writer.Bypass(), "Downloaded %s\n", f[1])
 	}
-
-	fmt.Fprintln(writer, "Finished: Downloaded 100GB")
+	_, _ = fmt.Fprintln(writer, "Finished: Downloaded 150GB")
 	writer.Stop() // flush and stop rendering
 }

--- a/terminal_size.go
+++ b/terminal_size.go
@@ -1,0 +1,37 @@
+package uilive
+
+import (
+	"os"
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+type windowSize struct {
+	rows    uint16
+	cols    uint16
+	xPixels uint16
+	yPixels uint16
+}
+
+var out *os.File
+var err error
+var sz windowSize
+
+func getTermSize() (int, int) {
+	if runtime.GOOS == "openbsd" {
+		out, err = os.OpenFile("/dev/tty", os.O_RDWR, 0)
+		if err != nil {
+			os.Exit(1)
+		}
+
+	} else {
+		out, err = os.OpenFile("/dev/tty", os.O_WRONLY, 0)
+		if err != nil {
+			os.Exit(1)
+		}
+	}
+	_, _, _ = syscall.Syscall(syscall.SYS_IOCTL,
+		out.Fd(), uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(&sz)))
+	return int(sz.cols), int(sz.rows)
+}

--- a/writer_posix.go
+++ b/writer_posix.go
@@ -4,11 +4,12 @@ package uilive
 
 import (
 	"fmt"
+	"strings"
 )
 
+// clear the line and move the cursor up
+var clear = fmt.Sprintf("%c[%dA%c[2K", ESC, 1, ESC)
+
 func (w *Writer) clearLines() {
-	for i := 0; i < w.lineCount; i++ {
-		fmt.Fprintf(w.Out, "%c[2K", ESC)     // clear the line
-		fmt.Fprintf(w.Out, "%c[%dA", ESC, 1) // move the cursor up
-	}
+	_, _ = fmt.Fprint(w.Out, strings.Repeat(clear, w.lineCount))
 }

--- a/writer_windows.go
+++ b/writer_windows.go
@@ -4,7 +4,6 @@ package uilive
 
 import (
 	"fmt"
-	"github.com/mattn/go-isatty"
 	"syscall"
 	"unsafe"
 )
@@ -17,6 +16,9 @@ var (
 	procFillConsoleOutputCharacter = kernel32.NewProc("FillConsoleOutputCharacterW")
 	procFillConsoleOutputAttribute = kernel32.NewProc("FillConsoleOutputAttribute")
 )
+
+// clear the line and move the cursor up
+var clear = fmt.Sprintf("%c[%dA%c[2K", ESC, 1, ESC)
 
 type short int16
 type dword uint32
@@ -48,10 +50,7 @@ func (w *Writer) clearLines() {
 		ok = false
 	}
 	if !ok {
-		for i := 0; i < w.lineCount; i++ {
-			fmt.Fprintf(w.Out, "%c[%dA", ESC, 0) // move the cursor up
-			fmt.Fprintf(w.Out, "%c[2K\r", ESC)   // clear the line
-		}
+		_, _ = fmt.Fprint(w.Out, strings.Repeat(clear, w.lineCount))
 		return
 	}
 	fd := f.Fd()


### PR DESCRIPTION
Hello @gosuri ,

In this PR, I have fixed the following features:

#3 - I have added code for the library to be able to detect the width of the terminal and adjust the writing accordingly so the last line is not overwritten
#4 - I have managed to fix this in part due to #3 above and also using strings.Repeat() instead of a loop.
#11 - I have updated the clearline function to move the cursor up and then clear the line. This has fixed the issue.

Reading #14 and the writer.Bypass(), I got inspired to implement the writer.Newline() feature that now allows us to write to multiple lines simultaneously. Result is something like this:

![render1554955255840-min](https://user-images.githubusercontent.com/25657923/55930003-ea49a980-5c3c-11e9-8200-33d4838ce5e3.gif)

Please review and let me know if any further edits are required. I want to help get this library up and running once again. I would readily make the fixes and push the updates.

Regards,
Ajitem

