### PR TITLE
getTermSize return 0 when no tty with process

### DIFF
--- a/terminal_size.go
+++ b/terminal_size.go
@@ -22,13 +22,13 @@ func getTermSize() (int, int) {
 	if runtime.GOOS == "openbsd" {
 		out, err = os.OpenFile("/dev/tty", os.O_RDWR, 0)
 		if err != nil {
-			os.Exit(1)
+			return 0, 0
 		}
 
 	} else {
 		out, err = os.OpenFile("/dev/tty", os.O_WRONLY, 0)
 		if err != nil {
-			os.Exit(1)
+			return 0, 0
 		}
 	}
 	_, _, _ = syscall.Syscall(syscall.SYS_IOCTL,


### PR DESCRIPTION
when program is started by supervisord, there's no tty associated its process.  
os.Exit(1) makes process failed.

The fix is to return 0 windows size when there's no tty.