### PR TITLE
Fix windows build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,27 @@
 language: go
 sudo: false
+
+matrix:
+  include:
+    - go: 1.4
+      os: linux
+    - go: tip
+      os: linux
+      env: CROSS_COMPILE=true
+    - go: tip
+      os: osx
+
 before_install:
-  - go get "github.com/nsf/termbox-go"
+  - if [ "$CROSS_COMPILE" = "true" ]; then sudo apt update; fi
+
 install:
-  - go get ./...
-go:
-  - 1.4
-  - tip
+  - if [ "$CROSS_COMPILE" = "true" ]; then sudo apt install libc6-dev-i386; fi
+  - if [ "$CROSS_COMPILE" = "true" ]; then sudo apt install gcc-mingw-w64; fi
+  - go get github.com/nsf/termbox-go
+  - if [ "$TRAVIS_OS_NAME" = "linux" -a "$CROSS_COMPILE" = "true" ]; then go get github.com/mattn/go-isatty ; fi
+  - go get -t -v ./...
+
+script:
+  - go build
+  - go test
+  - if [ "$TRAVIS_OS_NAME" = "linux" -a "$CROSS_COMPILE" = "true" ]; then env GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc go build -v; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
 sudo: false
+before_install:
+  - go get "github.com/nsf/termbox-go"
 install:
   - go get ./...
 go:

--- a/terminal_size.go
+++ b/terminal_size.go
@@ -1,37 +1,14 @@
 package uilive
 
 import (
-	"os"
-	"runtime"
-	"syscall"
-	"unsafe"
+	"github.com/nsf/termbox-go"
 )
 
-type windowSize struct {
-	rows    uint16
-	cols    uint16
-	xPixels uint16
-	yPixels uint16
-}
-
-var out *os.File
-var err error
-var sz windowSize
-
 func getTermSize() (int, int) {
-	if runtime.GOOS == "openbsd" {
-		out, err = os.OpenFile("/dev/tty", os.O_RDWR, 0)
-		if err != nil {
-			os.Exit(1)
-		}
-
-	} else {
-		out, err = os.OpenFile("/dev/tty", os.O_WRONLY, 0)
-		if err != nil {
-			os.Exit(1)
-		}
+	if err := termbox.Init(); err != nil {
+		panic(err)
 	}
-	_, _, _ = syscall.Syscall(syscall.SYS_IOCTL,
-		out.Fd(), uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(&sz)))
-	return int(sz.cols), int(sz.rows)
+	w, h := termbox.Size()
+	termbox.Close()
+	return w, h
 }

--- a/writer_windows.go
+++ b/writer_windows.go
@@ -4,8 +4,10 @@ package uilive
 
 import (
 	"fmt"
+	"strings"
 	"syscall"
 	"unsafe"
+	"github.com/mattn/go-isatty"
 )
 
 var kernel32 = syscall.NewLazyDLL("kernel32.dll")


### PR DESCRIPTION
This includes:

* fix non-linux builds
* fix Travis-CI build
* add Travis-CI build on OSX
* add Travis-CI cross-build for Windows

At the current state, the library faisl to build on windows, which causes any dependent packages that build on windows to fail too.