### PR TITLE
Fix getTermSize() for Windows

### DIFF
--- a/terminal_size_windows.go
+++ b/terminal_size_windows.go
@@ -3,61 +3,21 @@
 package uilive
 
 import (
-	"math"
-	"syscall"
+	"os"
 	"unsafe"
 )
 
-type consoleFontInfo struct {
-	font     uint32
-	fontSize coord
-}
-
-const (
-	SmCxMin = 28
-	SmCyMin = 29
-)
-
-var (
-	tmpConsoleFontInfo        consoleFontInfo
-	moduleUser32              = syscall.NewLazyDLL("user32.dll")
-	procGetCurrentConsoleFont = kernel32.NewProc("GetCurrentConsoleFont")
-	getSystemMetrics          = moduleUser32.NewProc("GetSystemMetrics")
-)
-
-func getCurrentConsoleFont(h syscall.Handle, info *consoleFontInfo) (err error) {
-	r0, _, e1 := syscall.Syscall(
-		procGetCurrentConsoleFont.Addr(), 3, uintptr(h), 0, uintptr(unsafe.Pointer(info)),
-	)
-	if int(r0) == 0 {
-		if e1 != 0 {
-			err = error(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
 func getTermSize() (int, int) {
-	out, err := syscall.Open("CONOUT$", syscall.O_RDWR, 0)
+	out, err := os.Open("CONOUT$")
 	if err != nil {
 		return 0, 0
 	}
 
-	x, _, err := getSystemMetrics.Call(SmCxMin)
-	y, _, err := getSystemMetrics.Call(SmCyMin)
-
-	if x == 0 || y == 0 {
-		if err != nil {
-			panic(err)
-		}
+	var csbi consoleScreenBufferInfo
+	ret, _, _ := procGetConsoleScreenBufferInfo.Call(out.Fd(), uintptr(unsafe.Pointer(&csbi)))
+	if ret == 0 {
+		return 0, 0
 	}
 
-	err = getCurrentConsoleFont(out, &tmpConsoleFontInfo)
-	if err != nil {
-		panic(err)
-	}
-
-	return int(math.Ceil(float64(x) / float64(tmpConsoleFontInfo.fontSize.x))), int(math.Ceil(float64(y) / float64(tmpConsoleFontInfo.fontSize.y)))
+	return int(csbi.window.right - csbi.window.left + 1), int(csbi.window.bottom - csbi.window.top + 1)
 }

--- a/terminal_size_windows.go
+++ b/terminal_size_windows.go
@@ -12,6 +12,7 @@ func getTermSize() (int, int) {
 	if err != nil {
 		return 0, 0
 	}
+	defer out.Close()
 
 	var csbi consoleScreenBufferInfo
 	ret, _, _ := procGetConsoleScreenBufferInfo.Call(out.Fd(), uintptr(unsafe.Pointer(&csbi)))


### PR DESCRIPTION
Original approach used `GetSystemMetrics()` which actually returned _minimal possible_ size of a window in pixels (most likely even without paying attention to non-zero border sizes).

I'm switching it to already used `GetConsoleScreenBufferInfo()` (already used in `writer_windows.go`) which among others returns currently visible window (from which terminal size could be easily calculated).

Without that fix uiprogress on Windows almost always clears the window because it erroneously detects overflows when they aren't actually present.