### PR TITLE
Fix wrong screen drawing by not counting ASCII color codes

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -94,13 +94,19 @@ func (w *Writer) Flush() error {
 		escaping    bool
 	)
 
-	for _, b := range w.buf.Bytes() {
+	bytes := w.buf.Bytes()
+	bytesLen := len(bytes)
+	for i, b := range bytes {
 		switch {
 		case b == '\n':
 			lines++
 			currentLine.Reset()
 		case b == ESC:
-			escaping = true
+			// All ASCII escape sequences start with ESC, followed by a second
+			// byte in the 0x40 to 0x5F range.
+			if i < bytesLen-1 && bytes[i+1] >= 0x40 && bytes[i+1] <= 0x5F {
+				escaping = true
+			}
 		case escaping && b == ASCII_END_COLOR_CODE:
 			escaping = false
 		default:


### PR DESCRIPTION
The previous code assumed that it could count every byte in the current
line towards the length of the visible line.

With invisible characters, though, such as ASCII color codes, the count
was wrong and lead to the output to "climb up the screen" because the
overflow handling broke and too many newlines were emitted.

The fix here introduces a little "state switch" that flips on when we
come across an ESC character and turns to off when we come across 'm',
the character that terminates an ASCII color code.

Here is code to reproduce the issue: https://gist.github.com/mrnugget/f46caf71b214ae6b6ffa9880a0036003

**Notably missing**: not all characters that _end_ an escape sequence are supported.

#### Before

![before_fix](https://user-images.githubusercontent.com/1185253/73253706-54780e80-41bd-11ea-8a21-60251a1d88c5.gif)

#### After

![after_fix](https://user-images.githubusercontent.com/1185253/73253719-5b9f1c80-41bd-11ea-8302-e7159961c0f4.gif)