### PR TITLE
Ability to remove escape sequence

### DIFF
--- a/writer_posix.go
+++ b/writer_posix.go
@@ -8,8 +8,8 @@ import (
 )
 
 // clear the line and move the cursor up
-var clear = fmt.Sprintf("%c[%dA%c[2K", ESC, 1, ESC)
+var Clear = fmt.Sprintf("%c[%dA%c[2K", ESC, 1, ESC)
 
 func (w *Writer) clearLines() {
-	_, _ = fmt.Fprint(w.Out, strings.Repeat(clear, w.lineCount))
+	_, _ = fmt.Fprint(w.Out, strings.Repeat(Clear, w.lineCount))
 }

--- a/writer_windows.go
+++ b/writer_windows.go
@@ -19,7 +19,7 @@ var (
 )
 
 // clear the line and move the cursor up
-var clear = fmt.Sprintf("%c[%dA%c[2K\r", ESC, 0, ESC)
+var Clear = fmt.Sprintf("%c[%dA%c[2K\r", ESC, 0, ESC)
 
 type short int16
 type dword uint32
@@ -51,7 +51,7 @@ func (w *Writer) clearLines() {
 		ok = false
 	}
 	if !ok {
-		_, _ = fmt.Fprint(w.Out, strings.Repeat(clear, w.lineCount))
+		_, _ = fmt.Fprint(w.Out, strings.Repeat(Clear, w.lineCount))
 		return
 	}
 	fd := f.Fd()


### PR DESCRIPTION
In cases where I might want to write progress to a file (instead of terminal), I would not be needing the escape sequences in the output. Thus, I've made the Clear variable global, so that we could set the escape sequence to blank string if required. 