### PR TITLE
fixbug terminal_size.go

### DIFF
--- a/terminal_size.go
+++ b/terminal_size.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package uilive
@@ -10,8 +11,10 @@ import (
 )
 
 type windowSize struct {
-	rows    uint16
-	cols    uint16
+	row    uint16
+	col    uint16
+	xpixel uint16
+	ypixel uint16
 }
 
 var out *os.File
@@ -33,5 +36,5 @@ func getTermSize() (int, int) {
 	}
 	_, _, _ = syscall.Syscall(syscall.SYS_IOCTL,
 		out.Fd(), uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(&sz)))
-	return int(sz.cols), int(sz.rows)
+	return int(sz.col), int(sz.row)
 }


### PR DESCRIPTION
ttysize structure has long been obsolete, the ioctl for ttysize was unsupported by kernel 2.6.16, change windowSize to winsize.

windowSize struct is 32bit but winsize is 64bit, which will cause cross border  error.